### PR TITLE
DOC-23 - added information about required software

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ The documentation is delivered via a Read The Docs (RTD) website.  We are levera
 
 I have not formally documented the usage requirements other than the commands to run to build and lint the docs.  In general, the build process uses the `sphinx-build` command behind the scenes.  Please consider creating a pull request to improve this README if/when you start contributing to this documentation.  Thanks...
 
+## Installing required software
+
+1. Install Sphinx-build https://www.sphinx-doc.org/en/master/usage/installation.html
+2. Install Tox https://tox.readthedocs.io/en/latest/install.html
+
+
 ## Building the docs
 
 Build the docs static site.


### PR DESCRIPTION
https://jira.tungsten.io/projects/DOC/issues/DOC-23

Added information with links to Sphinx-build and Tox.