### PR TITLE
DOC-44 Tox code check fails because github is case insensitive

### DIFF
--- a/governance/index.rst
+++ b/governance/index.rst
@@ -153,20 +153,20 @@ reference.
 -  TC: Technical Committee
 -  TSC: Technical Steering Committee
 
-.. _Technical Charter: tungsten-fabric-project-technical-charter.rst
-.. _Community Governance Document: tungsten-fabric-community-governance.rst
-.. _Architecture Review Board: architecture-review-board/arb-members.rst
-.. _Community Committee: community-committee/cc-members.rst
-.. _Technical Committee: technical-committee/tc-members.rst
-.. _Active Community Contributors: acc-members.rst
-.. _TSC Approved Active Technical Contributors: tsc-atc-members.rst
+.. _Technical Charter: tungsten-fabric-project-technical-charter.html
+.. _Community Governance Document: tungsten-fabric-community-governance.html
+.. _Architecture Review Board: architecture-review-board/arb-members.html
+.. _Community Committee: community-committee/cc-members.html
+.. _Technical Committee: technical-committee/tc-members.html
+.. _Active Community Contributors: acc-members.html
+.. _TSC Approved Active Technical Contributors: tsc-atc-members.html
 .. _Election Mechanics: https://wiki.tungsten.io/display/TUN/Election+Mechanics
 .. _this diagram: tsc-voters-and-candidates/tsc-voters-and-candidates-diagram.png
-.. _Sections 3.2 and 5.2.3.2.3: tungsten-fabric-community-governance.rst
-.. _Section 5.2.4.2.1: tungsten-fabric-community-governance.rst
-.. _Section 5.2.4.2.3: tungsten-fabric-community-governance.rst
-.. _Section 5.2.2: tungsten-fabric-community-governance.rst
-.. _Section 5.2.2: tungsten-fabric-community-governance.rst
-.. _Section 2: tungsten-fabric-project-technical-charter.rst
-.. _Section 5: tungsten-fabric-community-governance.rst
-.. _Section 5.2.4.3: tungsten-fabric-community-governance.rst
+.. _Sections 3.2 and 5.2.3.2.3: tungsten-fabric-community-governance.html
+.. _Section 5.2.4.2.1: tungsten-fabric-community-governance.html
+.. _Section 5.2.4.2.3: tungsten-fabric-community-governance.html
+.. _Section 5.2.2: tungsten-fabric-community-governance.html
+.. _Section 5.2.2: tungsten-fabric-community-governance.html
+.. _Section 2: tungsten-fabric-project-technical-charter.html
+.. _Section 5: tungsten-fabric-community-governance.html
+.. _Section 5.2.4.3: tungsten-fabric-community-governance.html


### PR DESCRIPTION
https://jira.tungsten.io/projects/DOC/issues/DOC-44

in index.rst there is a link to User/index.rst

In repo that folder is named "User" but github is case insensitive and treats it as "users". That creates a problem for "Tox -e docs" command used for generating documentation. In local environment, it will work but on github it will fail. The solution is to change the name of the folder to lowercase.

Signed-off-by: Szymon Golebiewski <szymon.v@gmail.com>