### PR TITLE
[DOC-92] Exclude docsTools from sphinx

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -19,6 +19,7 @@ exclude_patterns:
   - _build
   - Thumbs.db
   - .tox
+  - docsTools
 todo_include_todos: false
 
 html_favicon: _static/favicon.ico


### PR DESCRIPTION
In future pull request there will be new folder added to the repo. This folder will include additional tools used by docs project so it needs to be excluded from the sphinx-build command