### PR TITLE
[WIP] Update building of the TF documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ In addition to building, we can and should run a linter against the content.
 $ tox -e docs-linkcheck
 ```
 
+## Building and running the linter
+
+To build documentation and execute link checking in one run.
+```
+$ tox -e docs-all
+```
+
+## Building documentation locally
+
+Local building will establish re-usable pip cache under tox workdir (```.tox/```).
+
+```
+$ tox -e docs-dev
+```
+
+Additionally you can pass additional flags to ```sphinx-build``` i.e speed up building process
+with ```-j <n>``` flag.
+
+```
+$ tox -e docs-dev -- -j 4
+```
+
 ## Troubleshooting
 
 In case tox will report errors like ```module not found``` when that module was previously used

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,28 @@ minversion = 1.6
 envlist =
     docs
     docs-linkcheck
+    docs-all
+    docs-dev
 skipsdist = true
 
+[testenv]
+deps = -r requirements.txt
+
 [testenv:docs]
-deps = -rrequirements.txt
 commands = sphinx-build -W -b html -n -d {envtmpdir}/doctrees ./ {toxinidir}/_build/html
 
 [testenv:docs-linkcheck]
-deps = -rrequirements.txt
 commands = sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees ./ {toxinidir}/_build/linkcheck
+
+[testenv:docs-all]
+commands =
+    {[testenv:docs]commands}
+    {[testenv:docs-linkcheck]commands}
+
+[testenv:docs-dev]
+deps =
+    -r requirements.txt
+    --cache-dir {toxworkdir}/cache
+commands =
+    {[testenv:docs]commands} --keep-going {posargs}
+    {[testenv:docs-linkcheck]commands} --keep-going {posargs}


### PR DESCRIPTION
* Building process with `tox` is pulling dependencies
from other repositories from the internet. We introduce
new tox target `docs-dev` to incorporate package caching
for consecutive builds.

* Build of the documentation stops after each warning.
That makes correcting very hard as one can only make one
correction at a time and re-run the build. We introduce
`docs-dev` to local development which will build whole
documentation.

* New `docs-all` target building documentation and doing
the link check at same run.